### PR TITLE
feat: add palette storage and UI

### DIFF
--- a/Main
+++ b/Main
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import { savePalette, loadPalettes } from "./src/utils/storage";
 
 /**
  * Palette Muse – Liquid Glass UI Prototype
@@ -348,6 +349,7 @@ export default function PaletteMuse() {
   const [palette, setPalette] = useState(() => store.get("pm_palette", makePalette(seedHue)));
   const [savedColors, setSavedColors] = useState(() => store.get("pm_savedColors", []));
   const [groups, setGroups] = useState(() => store.get("pm_groups", [])); // [{name, colors:[] }]
+  const [savedPalettes, setSavedPalettes] = useState(() => loadPalettes());
   const [projects, setProjects] = useState(() => store.get("pm_projects", [])); // [{name, phases:{Exploration:[], Direction:[], Refinement:[], Production:[], Handoff:[]}}]
   const [activeProjectIdx, setActiveProjectIdx] = useState(() => store.get("pm_activeProjectIdx", -1));
   const [lastInk, setLastInk] = useState("#CCCCCC");
@@ -367,6 +369,15 @@ export default function PaletteMuse() {
   const randomBest = () => {
     const { palette: p, seedHue: h } = aiBestMatch();
     setSeedHue(h); setPalette(p);
+  };
+
+  const handleSavePalette = () => {
+    const updated = savePalette(palette);
+    setSavedPalettes(updated);
+  };
+
+  const handleLoadPalettes = () => {
+    setSavedPalettes(loadPalettes());
   };
 
   const copy = async (text) => {
@@ -504,6 +515,21 @@ export default function PaletteMuse() {
                 );
               })}
             </div>
+
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <button onClick={handleSavePalette} className="px-2 py-1 rounded-xl bg-white/40 hover:bg-white/60 border border-white/40 text-sm"><Icon name="save"/> Enregistrer la palette</button>
+              <button onClick={handleLoadPalettes} className="px-2 py-1 rounded-xl bg-white/40 hover:bg-white/60 border border-white/40 text-sm">Charger palettes sauvegardées</button>
+            </div>
+
+            {savedPalettes.length > 0 && (
+              <div className="mt-3 space-y-2 max-h-32 overflow-auto pr-1">
+                {savedPalettes.map((p,i)=>(
+                  <button key={i} onClick={()=>setPalette(p)} className="grid grid-cols-8 rounded-xl overflow-hidden border border-white/40">
+                    {p.map((c,ci)=>(<div key={ci} style={{background:c}} className="h-6"/>))}
+                  </button>
+                ))}
+              </div>
+            )}
 
             <div className="mt-4 flex flex-wrap items-center gap-2">
               {(["Exploration","Direction","Refinement","Production","Handoff"]).map(ph => (

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = 'pm_palettes';
+
+export function loadPalettes(): string[][] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function savePalette(palette: string[]): string[][] {
+  const palettes = loadPalettes();
+  palettes.push(palette);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(palettes));
+  } catch {
+    // ignore write errors
+  }
+  return palettes;
+}


### PR DESCRIPTION
## Summary
- implement `savePalette` and `loadPalettes` using localStorage
- add buttons to save current palette and load saved palettes
- display saved palettes for easy reuse

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ff8c4f84483319764433a0e35afa1